### PR TITLE
Change imports from package ool.web.model to ool.common.web.model (#2)

### DIFF
--- a/src/ool/intellij/plugin/editor/completion/JavaContext.java
+++ b/src/ool/intellij/plugin/editor/completion/JavaContext.java
@@ -9,8 +9,8 @@ import java.util.stream.Collectors;
 import ool.intellij.plugin.editor.completion.handler.TrailingPatternConsumer;
 import ool.intellij.plugin.lang.OxyTemplateInnerJs;
 import ool.intellij.plugin.psi.reference.innerjs.ExtenderProvider;
-import ool.web.model.BaseExtender;
-import ool.web.model.Extender;
+import ool.common.web.model.BaseExtender;
+import ool.common.web.model.Extender;
 
 import com.intellij.codeInsight.completion.CompletionContributor;
 import com.intellij.codeInsight.completion.CompletionParameters;

--- a/src/ool/intellij/plugin/psi/reference/innerjs/ExtenderProvider.java
+++ b/src/ool/intellij/plugin/psi/reference/innerjs/ExtenderProvider.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public class ExtenderProvider
 {
-    private static final String EXTENDER_INTERFACE_FQN = ool.web.model.ExtenderProvider.class.getName();
+    private static final String EXTENDER_INTERFACE_FQN = ool.common.web.model.ExtenderProvider.class.getName();
     @NonNls
     private static final String CLASS_GETTER_METHOD_MANE = "getExtendedClass";
     @NonNls

--- a/src/ool/intellij/plugin/psi/reference/innerjs/globals/GlobalVariableIndex.java
+++ b/src/ool/intellij/plugin/psi/reference/innerjs/globals/GlobalVariableIndex.java
@@ -43,9 +43,9 @@ public class GlobalVariableIndex implements CachedValueProvider<Map<String, Glob
             Key.create("GLOBAL_VARIABLES_KEY");
 
     @NonNls
-    private static final String MODEL_PROVIDER_REGISTRY_FQN = "ool.web.model.ondemand.ModelProviderRegistry";
+    private static final String MODEL_PROVIDER_REGISTRY_FQN = "ool.common.web.model.ondemand.ModelProviderRegistry";
     @NonNls
-    private static final String GLOBAL_MODEL_PROVIDER_FQN = "ool.web.model.ondemand.GlobalModelProvider";
+    private static final String GLOBAL_MODEL_PROVIDER_FQN = "ool.common.web.model.ondemand.GlobalModelProvider";
     @NonNls
     private static final String REGISTER_METHOD_NAME = "register";
     @NonNls

--- a/src/ool/intellij/plugin/psi/reference/innerjs/globals/GlobalVariableTypeProvider.java
+++ b/src/ool/intellij/plugin/psi/reference/innerjs/globals/GlobalVariableTypeProvider.java
@@ -5,7 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import ool.intellij.plugin.psi.reference.innerjs.InnerJsJavaTypeConverter;
-import ool.web.model.ondemand.GlobalModelProvider;
+import ool.common.web.model.ondemand.GlobalModelProvider;
 
 import com.google.common.collect.ImmutableList;
 import com.intellij.lang.javascript.psi.JSType;


### PR DESCRIPTION
The package ool.web.model in the common-web module has been renamed to ool.common.web.model.
Imports from this package needs to be in the template plugin changed too.